### PR TITLE
Update module path to correctly match package name

### DIFF
--- a/How-to-upgrade-to-Typescript-without-anybody-noticing-part-2.md
+++ b/How-to-upgrade-to-Typescript-without-anybody-noticing-part-2.md
@@ -328,7 +328,7 @@ the real thing later. Here's what you can do:
 2. Add the following code:
 
 ```ts
-declare module "eslint/lib/pattern-visitor" {
+declare module "eslint-scope/lib/pattern-visitor" {
     class OriginalPatternVisitor {
         constructor(x: any, y: any, z: any) {
         }


### PR DESCRIPTION
All surrounding code mentions `eslint-scope` and AFIAK there is no `lib/pattern-visitor` directly in the `eslint` package.